### PR TITLE
perf: Clean up `MemArray.create`

### DIFF
--- a/src/LibMemArray.sol
+++ b/src/LibMemArray.sol
@@ -47,10 +47,18 @@ library LibMemArray {
     function create() internal pure returns (MemArray newArray) {
         // linked lists always have a head node which does not contain a value
         // the tail, on the other hand, represents the last node (or head if size == 0)
-        Node memory head;
-        LinkedList memory list = LinkedList({size: 0, head: head, tail: head});
         assembly {
-            newArray := list
+            // Grab some free memory for the linked list fat pointer
+            let ptr := mload(0x40)
+            // Grab some free memory for the head node fat pointer
+            let head := add(ptr, 0x60)
+            // On initialization, the head and the tail point to the allocated head.
+            mstore(add(ptr, 0x20), head)
+            mstore(add(ptr, 0x40), head)
+            // Update the free memory pointer after 160 bytes of allocation
+            mstore(0x40, add(ptr, 0xA0))
+            // Return the linked list fat pointer
+            newArray := ptr
         }
     }
 

--- a/test/LibMemArray.t.sol
+++ b/test/LibMemArray.t.sol
@@ -7,7 +7,7 @@ import "../src/LibMemArray.sol";
 contract LibMemArrayTest is Test {
     using LibMemArray for *;
 
-    function testArr() public {
+    function testArr() public pure {
         MemArray arr = LibMemArray.create();
         arr.push(0x69);
         require(arr.get(0) == 0x69, "get 0");
@@ -37,10 +37,5 @@ contract LibMemArrayTest is Test {
         require(arr2.get(0) == 0x6000, "legacy get 0");
         require(arr2.get(1) == 0x6111, "legacy get 1");
         require(arr2.get(2) == 0x6222, "legacy get 2");
-
-
-
-
-
     }
 }


### PR DESCRIPTION
## Overview

Moves the `MemArray.create` method into an assembly block to reduce the number of unnecessary checks solc adds during the allocation of the empty `MemArray`.